### PR TITLE
chore: deleteNode also delete refs &testing

### DIFF
--- a/src/main/model/graph.ts
+++ b/src/main/model/graph.ts
@@ -1,3 +1,4 @@
+import { node } from '../../test/defs/any.js';
 import { GraphSchema } from '../schema/index.js';
 import * as t from '../types/index.js';
 import { MultiMap, serialize, shortId } from '../util/index.js';
@@ -73,6 +74,12 @@ export class Graph implements t.Graph {
         const i = this.nodes.findIndex(_ => _.id === nodeId);
         if (i > -1) {
             this.nodes.splice(i, 1);
+            for (const elem of Object.keys(this.refs)) {
+                const res = this.nodes.find(node => node.ref === elem);
+                if (res === undefined) {
+                    delete this.refs[elem];
+                }
+            }
             return true;
         }
         return false;

--- a/src/test/model/graph.test.ts
+++ b/src/test/model/graph.test.ts
@@ -69,15 +69,72 @@ describe('Graph', () => {
             assert.notEqual(graph.refs[node1.ref], graph.refs[node2.ref]);
         });
 
-        // it('does not create a node with the wrong type of URI');
     });
-
 
     describe('deleteNode', () => {
 
-        it('removes the node'); // create, a graph, create a node, test the delete func on this new node, then check if the node is still existing .length 0 (create graph with node in it)
-        it('removes unused refs'); // **not yet implemented** create a ref that is unused, call the delete on this ref, check the ref is not there.
-        it('does not remove used refs'); // **not yet implemented**create a ref that is used, call the delete on this ref, check the ref is still there.
+        it('removes the correct node', async () => {
+            const loader = new GraphLoader();
+            const graph = await loader.loadGraph({
+                nodes: [
+                    {
+                        id: 'res',
+                        ref: 'add',
+                        props: [
+                            { key: 'a', linkId: 'p' },
+                            { key: 'b', linkId: 'p' },
+                        ]
+                    },
+                    {
+                        id: 'p',
+                        ref: 'string',
+                        props: [
+                            { key: 'value', value: '42' },
+                        ]
+                    }
+                ],
+                refs: {
+                    add: runtime.defs['math.add'],
+                    string: runtime.defs['string'],
+                }
+            });
+            assert.strictEqual(Object.keys(graph.nodes).length, 2);
+            await graph.deleteNode('res');
+            assert.strictEqual(Object.keys(graph.nodes).length, 1);
+            assert.strictEqual(graph.nodes[0]['id'], 'p');
+        });
+        it('only removes unused refs', async () => {
+            const loader = new GraphLoader();
+            const graph = await loader.loadGraph({
+                nodes: [
+                    {
+                        id: 'res',
+                        ref: 'add',
+                        props: [
+                            { key: 'a', linkId: 'p' },
+                            { key: 'b', linkId: 'p' },
+                        ]
+                    },
+                    {
+                        id: 'p',
+                        ref: 'string',
+                        props: [
+                            { key: 'value', value: '42' },
+                        ]
+                    }
+                ],
+                refs: {
+                    add: runtime.defs['math.add'],
+                    string: runtime.defs['string'],
+                }
+            });
+            assert.strictEqual(Object.keys(graph.nodes).length, 2);
+            assert.strictEqual(Object.keys(graph.refs).length, 2);
+            await graph.deleteNode('res');
+            assert.strictEqual(Object.keys(graph.nodes).length, 1);
+            assert.strictEqual(Object.keys(graph.refs).length, 1);
+            assert.strictEqual(Object.keys(graph.refs)[0], 'string');
+        });
 
     });
 


### PR DESCRIPTION
GRAPH:
- Implemented the deletion of refs when a node is deleted on the deleteNode function:

breakdown >> if find() returns undefined > means that the ref in question is unused > that corresponding ref element is then deleted

GRAPH-TESTS:
- we previously had two pending tests but adding just one line checking that the remaining ref was the correct one 
'removes unused refs'
'does not remove used refs'

>> SO I changed that to only one test of
'only removes used refs'

it is checking both things at once.
Please review if all ok. Thanks!